### PR TITLE
Bump dpctl quota on dppy channel

### DIFF
--- a/scripts/cleanup-old-packages.py
+++ b/scripts/cleanup-old-packages.py
@@ -18,7 +18,7 @@ except ImportError:
 
 QUOTAS = {
     # lets try keeping at least 1Gb free. Total quota is 3Gb
-    "dppy/dpctl": 512 * 1024 * 1024,
+    "dppy/dpctl": (512 + 128) * 1024 * 1024,
     "dppy/dpnp": (512 - 128) * 1024 * 1024,
     "dppy/numba-dpex": 256 * 1024 * 1024,
     "dppy/numba-mlir": 512 * 1024 * 1024,


### PR DESCRIPTION
Recently there was support of new python 3.13 added into dpctl. It requires about 120 MB extra memory in the channel's storage to upload the new conda and wheels packages with python 3.13.
The current quota is not able to fit all the packages with the latest dpctl version. It results that every time dpctl is tiring to upload the packages, they will be cleaned up by that script.

Thus  that PR proposes to bump the quota to consider new dpctl requirement with python 3.13 support.