### PR TITLE
Increase quota for dpctl and dpnp to 1Gb each

### DIFF
--- a/scripts/cleanup-old-packages.py
+++ b/scripts/cleanup-old-packages.py
@@ -18,8 +18,8 @@ except ImportError:
 
 QUOTAS = {
     # lets try keeping at least 1Gb free. Total quota is 3Gb
-    "dppy/dpctl": (512 + 128) * 1024 * 1024,
-    "dppy/dpnp": (512 - 128) * 1024 * 1024,
+    "dppy/dpctl": 1024 * 1024 * 1024,
+    "dppy/dpnp": 1024 * 1024 * 1024,
     "dppy/numba-dpex": 256 * 1024 * 1024,
     "dppy/numba-mlir": 512 * 1024 * 1024,
     "dppy/dpbench": 128 * 1024 * 1024,


### PR DESCRIPTION
Increase quota allowance for `dpctl` and `dpnp`.

Our present usage is low, and we need the limit increased to be able to accommodate single snapshot of artifacts.

![image](https://github.com/user-attachments/assets/16db00a1-4f44-443d-9ffe-4e768c8ca733)
