### PR TITLE
Add GitHub workflow to autoupdate `pre-commit`

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Autoupdate pre-commit
+
+on:
+  # To be able to be triggered manually
+  workflow_dispatch:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '28 2 * * 6' # Saturday at 02:28 UTC
+
+permissions: read-all
+
+jobs:
+  autoupdate:
+    name: Autoupdate
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      # Needed to create a PR with autoupdate changes
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout DPNP repo
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: '3.13'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create a PR with autoupdate changes
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e #v7.0.8
+        with:
+          commit-message: 'chore: update pre-commit hooks'
+          add-paths: .pre-commit-config.yaml
+          branch: 'bot/pre-commit-autoupdate'
+          delete-branch: true
+          title: Weekly pre-commit autoupdate
+          body: |
+            This PR updates the `.pre-commit-config.yaml` using `pre-commit autoupdate`.
+          labels: autoupdate

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout DPNP repo
+      - name: Checkout devops-tools repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up python


### PR DESCRIPTION
The PR adds `.pre-commit-config.yaml` which implements GitHub workflow to have an automatic scheduled versions update for checks used in the `pre-commit`.